### PR TITLE
Added option to change fancyBox version

### DIFF
--- a/_jw_sig.xml
+++ b/_jw_sig.xml
@@ -19,6 +19,7 @@
                 <field name="jpg_quality" type="text" default="90" size="3" label="JW_PLG_SIG_TQ" description="JW_PLG_SIG_TQ_DESC" />
                 <field name="cache_expire_time" type="text" default="86400" size="3" label="JW_PLG_SIG_TCEXP" description="JW_PLG_SIG_TCEXP_DESC" />
                 <field name="memoryLimit" type="text" default="" size="3" label="JW_PLG_SIG_ML" description="JW_PLG_SIG_ML_DESC" />
+                <field name="fancybox_version" type="text" hint="3.5.7" default="3.5.7" label="JW_PLG_SIG_FB_VERSION" description="JW_PLG_SIG_FB_VERSION_DESC" />
             </fieldset>
         </fields>
     </config>

--- a/jw_sig.xml
+++ b/jw_sig.xml
@@ -25,6 +25,7 @@
         <param name="jpg_quality" type="text" default="90" size="6" label="JW_PLG_SIG_TQ" description="JW_PLG_SIG_TQ_DESC" />
         <param name="cache_expire_time" type="text" default="86400" size="6" label="JW_PLG_SIG_TCEXP" description="JW_PLG_SIG_TCEXP_DESC" />
         <param name="memoryLimit" type="text" default="" size="6" label="JW_PLG_SIG_ML" description="JW_PLG_SIG_ML_DESC" />
+        <param name="fancybox_version" type="text" hint="3.5.7" default="3.5.7" label="JW_PLG_SIG_FB_VERSION" description="JW_PLG_SIG_FB_VERSION_DESC" />
     </params>
     <!-- Files -->
     <files folder="plugin" destination="jw_sig">

--- a/plugin/jw_sig.php
+++ b/plugin/jw_sig.php
@@ -164,6 +164,8 @@ class plgContentJw_sig extends JPlugin
         $jpg_quality = $pluginParams->get('jpg_quality', 80);
         $showcaptions = 0;
         $cache_expire_time = $pluginParams->get('cache_expire_time', 3600) * 60; // Cache expiration time in minutes
+        $fancybox_version = $pluginParams->get('fancybox_version', '3.5.7');
+
         // Advanced
         $memoryLimit = (int)$pluginParams->get('memoryLimit');
         if ($memoryLimit) {

--- a/plugin/jw_sig.xml
+++ b/plugin/jw_sig.xml
@@ -19,6 +19,7 @@
                 <field name="jpg_quality" type="text" default="90" size="3" label="JW_PLG_SIG_TQ" description="JW_PLG_SIG_TQ_DESC" />
                 <field name="cache_expire_time" type="text" default="86400" size="3" label="JW_PLG_SIG_TCEXP" description="JW_PLG_SIG_TCEXP_DESC" />
                 <field name="memoryLimit" type="text" default="" size="3" label="JW_PLG_SIG_ML" description="JW_PLG_SIG_ML_DESC" />
+                <field name="fancybox_version" type="text" hint="3.5.7" default="3.5.7" label="JW_PLG_SIG_FB_VERSION" description="JW_PLG_SIG_FB_VERSION_DESC" />
             </fieldset>
         </fields>
     </config>

--- a/plugin/jw_sig/includes/js/jquery_fancybox/popup.php
+++ b/plugin/jw_sig/includes/js/jquery_fancybox/popup.php
@@ -14,11 +14,11 @@ $extraClass = 'fancybox-gallery';
 $customLinkAttributes = 'data-fancybox="gallery'.$gal_id.'"';
 
 $stylesheets = array(
-    'https://cdn.jsdelivr.net/gh/fancyapps/fancybox@3.5.7/dist/jquery.fancybox.min.css'
+    'https://cdn.jsdelivr.net/gh/fancyapps/fancybox@'.$fancybox_version.'/dist/jquery.fancybox.min.css'
 );
 $stylesheetDeclarations = array();
 $scripts = array(
-    'https://cdn.jsdelivr.net/gh/fancyapps/fancybox@3.5.7/dist/jquery.fancybox.min.js'
+    'https://cdn.jsdelivr.net/gh/fancyapps/fancybox@'.$fancybox_version.'/dist/jquery.fancybox.min.js'
 );
 
 if(!defined('PE_FANCYBOX_LOADED')){

--- a/plugin/language/en-GB/en-GB.plg_content_jw_sig.ini
+++ b/plugin/language/en-GB/en-GB.plg_content_jw_sig.ini
@@ -11,6 +11,8 @@ JW_PLG_SIG_XML_DESC="<div style='background:#fff;padding:20px;color:#000;'><h2>J
 
 ; BACKEND
 JW_PLG_SIG_DO_NOT_LOAD_THE_JQUERY_LIBRARY="Do not load the jQuery library"
+JW_PLG_SIG_FB_VERSION="fancyBox Version"
+JW_PLG_SIG_FB_VERSION_DESC="Change the version number outlined in this field if you want to use a different version of fancyBox."
 JW_PLG_SIG_JQUERY_HANDLING="jQuery library handling"
 JW_PLG_SIG_JQUERY_HANDLING_DESC="Some popup engines require the jQuery JavaScript library to function. Choose which version of jQuery you want to use or completely disable it if it's already being loaded by another extension - e.g. K2."
 JW_PLG_SIG_LOAD_V1_8_X_LATEST_COPY="Load v1.8.x latest"


### PR DESCRIPTION
Added an option to give users the opportunity to switch between fancyBox versions. This is especially useful if the plugin does not receive an update for a longer time. So the user has the option to switch the version if needed by himself.